### PR TITLE
Readout motor wattage and set constants

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -426,6 +426,11 @@ int main(void)
   set_Pin(OUT1_pin, HIGH);  // reference pin for motor wattage
   set_Pin(OUT2_pin, HIGH);	// reference pin for feedback header
 
+  // Check if robot has 30 W or 50 W motors (jumper = 50 W, no jumper = 30 W)
+  MOTORS_50W = read_Pin(IN1_pin);
+  // Initialize control constants
+  control_util_Init();
+
   Putty_Init();
   wheels_Init();
   stateControl_Init();
@@ -441,11 +446,6 @@ int main(void)
   MTi = MTi_Init(NO_ROTATION_TIME, XSENS_FILTER);
   uint16_t ID = get_Id();
   Putty_printf("\n\rID: %u\n\r",ID);
-  
-  // Check if robot has 30 W or 50 W motors (jumper = 50 W, no jumper = 30 W)
-  MOTORS_50W = read_Pin(IN1_pin);
-  // Initialize control constants
-  control_util_Init();
 
   // start the wireless receiver
   // transmit feedback packet for every received packet if wirelessFeedback==true

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -444,6 +444,8 @@ int main(void)
   
   // Check if robot has 30 W or 50 W motors (jumper = 50 W, no jumper = 30 W)
   MOTORS_50W = read_Pin(IN1_pin);
+  // Initialize control constants
+  control_util_Init();
 
   // start the wireless receiver
   // transmit feedback packet for every received packet if wirelessFeedback==true
@@ -501,7 +503,6 @@ int main(void)
 		  clearReceivedData(&receivedData);
 	  }
 
-	  Putty_printf("Motors 50 W? %u\n\r", MOTORS_50W);
 	  test_Update(&receivedData);
 	  executeCommands(&receivedData);
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -43,6 +43,7 @@
 
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "control_util.h"
 #include "gpio_util.h"
 #include "tim_util.h"
 #include "peripheral_util.h"
@@ -422,6 +423,7 @@ int main(void)
   MX_TIM14_Init();
   /* USER CODE BEGIN 2 */
 
+  set_Pin(OUT1_pin, HIGH);  // reference pin for motor wattage
   set_Pin(OUT2_pin, HIGH);	// reference pin for feedback header
 
   Putty_Init();
@@ -433,12 +435,15 @@ int main(void)
   dribbler_Init();
   ballSensor_Init();
   buzzer_Init();
-  
+
   SX = Wireless_Init(COMMAND_CHANNEL, COMM_SPI);
   wirelessFeedback = true;//read_Pin(IN2_pin);	// check if we should enable feedback or not (jumper = feedback)
   MTi = MTi_Init(NO_ROTATION_TIME, XSENS_FILTER);
   uint16_t ID = get_Id();
   Putty_printf("\n\rID: %u\n\r",ID);
+  
+  // Check if robot has 30 W or 50 W motors (jumper = 50 W, no jumper = 30 W)
+  MOTORS_50W = read_Pin(IN1_pin);
 
   // start the wireless receiver
   // transmit feedback packet for every received packet if wirelessFeedback==true
@@ -496,6 +501,7 @@ int main(void)
 		  clearReceivedData(&receivedData);
 	  }
 
+	  Putty_printf("Motors 50 W? %u\n\r", MOTORS_50W);
 	  test_Update(&receivedData);
 	  executeCommands(&receivedData);
 

--- a/Core/Src/stateControl.c
+++ b/Core/Src/stateControl.c
@@ -27,9 +27,17 @@ static float angleControl(float angleRef, float angle);
 
 int stateControl_Init(){
 	status = on;
-	initPID(&stateK[body_x], 0.1, 0.0, 0.0);
-	initPID(&stateK[body_y], 0.4, 0.0, 0.0);
-	initPID(&stateK[body_w], 20.0, 30.0, 0.0);
+	if (MOTORS_50W) {
+		// 50 W
+		initPID(&stateK[body_x], 0.1, 0.0, 0.0);
+		initPID(&stateK[body_y], 0.4, 0.0, 0.0);
+		initPID(&stateK[body_w], 20.0, 30.0, 0.0);
+	} else {
+		// 30 W
+		initPID(&stateK[body_x], 0.1, 0.0, 0.0);
+		initPID(&stateK[body_y], 0.4, 0.0, 0.0);
+		initPID(&stateK[body_w], 20.0, 30.0, 0.0);
+	}
 	HAL_TIM_Base_Start_IT(TIM_CONTROL);
 	return 0;
 }

--- a/Core/Src/wheels.c
+++ b/Core/Src/wheels.c
@@ -43,7 +43,11 @@ static void SetDir();
 int wheels_Init(){
 	wheels_state = on;
 	for (wheel_names wheel = wheels_RF; wheel <= wheels_LF; wheel++) {
-		initPID(&wheelsK[wheel], 7.0, 0.0, 0.0);
+		if (MOTORS_50W) {
+			initPID(&wheelsK[wheel], 7.0, 0.0, 0.0); // 50 W
+		} else {
+			initPID(&wheelsK[wheel], 7.0, 0.0, 0.0); // 30 W
+		}
 	}
 	HAL_TIM_Base_Start(ENC_RF); //RF
 	HAL_TIM_Base_Start(ENC_RB); //RB

--- a/Util/control_util.h
+++ b/Util/control_util.h
@@ -40,8 +40,12 @@ bool MOTORS_50W;			// wattage of motors, true = 50 W, false = 30 W
 #define GEAR_RATIO 2.5F // gear ratio between motor and wheel
 #define MAX_PWM 3000 // defined in CubeMX
 #define PWM_LIMIT MAX_PWM // should be equal to MAX_PWM by default
-float MAX_VOLTAGE; // see datasheet
+float MAX_VOLTAGE; // [V] see datasheet
+#define MAX_VOLTAGE_30W 12.0
+#define MAX_VOLTAGE_50W 24.0
 float SPEED_CONSTANT; //[(rad/s)/V] see datasheet
+#define SPEED_CONSTANT_30W 374.0
+#define SPEED_CONSTANT_50W 285.0
 #define PULSES_PER_ROTATION (float)4*1024 // number of pulses of the encoder per rotation of the motor (see datasheet)
 
 float OMEGAtoPWM; // conversion factor from wheel speed [rad/s] to required PWM on the motor
@@ -49,7 +53,8 @@ float OMEGAtoPWM; // conversion factor from wheel speed [rad/s] to required PWM 
 
 // Control
 #define YAW_MARGIN (0.5F/180.0F)*(float)M_PI // margin at which the I-value of the PID is reset to 0
-float WHEEL_REF_LIMIT; // Limit the maximum wheel reference to leave room for the wheels PID
+float WHEEL_REF_LIMIT; // [rad/s] Limit the maximum wheel reference to leave room for the wheels PID
+#define WHEEL_REF_LIMIT_PWM 2200 // [pwm]
 
 // Geneva
 #define GENEVA_CAL_EDGE_CNT 4100		// the amount of encoder counts from one edge to the other
@@ -119,10 +124,10 @@ typedef struct PIDstruct PIDvariables;
  * Initializes motor wattage dependent constants
  */
 inline void control_util_Init() {
-	MAX_VOLTAGE = MOTORS_50W ? 24.0 : 12.0;
-	SPEED_CONSTANT = 2*M_PI/60.0 * (MOTORS_50W ? 285.0 : 374.0);
+	MAX_VOLTAGE = MOTORS_50W ? MAX_VOLTAGE_50W : MAX_VOLTAGE_30W;
+	SPEED_CONSTANT = 2*M_PI/60.0 * (MOTORS_50W ? SPEED_CONSTANT_50W : SPEED_CONSTANT_30W);
 	OMEGAtoPWM = (1/SPEED_CONSTANT)*(MAX_PWM/MAX_VOLTAGE)*GEAR_RATIO;
-	WHEEL_REF_LIMIT = 2200/OMEGAtoPWM;
+	WHEEL_REF_LIMIT = WHEEL_REF_LIMIT_PWM/OMEGAtoPWM;
 }
 
 //Initializes the PID values

--- a/Util/control_util.h
+++ b/Util/control_util.h
@@ -40,16 +40,16 @@ bool MOTORS_50W;			// wattage of motors, true = 50 W, false = 30 W
 #define GEAR_RATIO 2.5F // gear ratio between motor and wheel
 #define MAX_PWM 3000 // defined in CubeMX
 #define PWM_LIMIT MAX_PWM // should be equal to MAX_PWM by default
-#define MAX_VOLTAGE 12 // see datasheet
-#define SPEED_CONSTANT (2*M_PI/60.0 * 374.0) //[(rad/s)/V] see datasheet
+float MAX_VOLTAGE; // see datasheet
+float SPEED_CONSTANT; //[(rad/s)/V] see datasheet
 #define PULSES_PER_ROTATION (float)4*1024 // number of pulses of the encoder per rotation of the motor (see datasheet)
 
-#define OMEGAtoPWM (1/SPEED_CONSTANT)*(MAX_PWM/MAX_VOLTAGE)*GEAR_RATIO // conversion factor from wheel speed [rad/s] to required PWM on the motor
+float OMEGAtoPWM; // conversion factor from wheel speed [rad/s] to required PWM on the motor
 #define ENCODERtoOMEGA (float)2*M_PI/(TIME_DIFF*GEAR_RATIO*PULSES_PER_ROTATION) // conversion factor from number of encoder pulses to wheel speed [rad/s]
 
 // Control
 #define YAW_MARGIN (0.5F/180.0F)*(float)M_PI // margin at which the I-value of the PID is reset to 0
-#define WHEEL_REF_LIMIT 2200/OMEGAtoPWM // Limit the maximum wheel reference to leave room for the wheels PID
+float WHEEL_REF_LIMIT; // Limit the maximum wheel reference to leave room for the wheels PID
 
 // Geneva
 #define GENEVA_CAL_EDGE_CNT 4100		// the amount of encoder counts from one edge to the other
@@ -115,6 +115,15 @@ struct PIDstruct{
 typedef struct PIDstruct PIDvariables;
 
 ///////////////////////////////////////////////////// FUNCTIONS
+/**
+ * Initializes motor wattage dependent constants
+ */
+inline void control_util_Init() {
+	MAX_VOLTAGE = MOTORS_50W ? 24.0 : 12.0;
+	SPEED_CONSTANT = 2*M_PI/60.0 * (MOTORS_50W ? 285.0 : 374.0);
+	OMEGAtoPWM = (1/SPEED_CONSTANT)*(MAX_PWM/MAX_VOLTAGE)*GEAR_RATIO;
+	WHEEL_REF_LIMIT = 2200/OMEGAtoPWM;
+}
 
 //Initializes the PID values
 static void initPID(PIDvariables* PID, float kP, float kI, float kD) {

--- a/Util/control_util.h
+++ b/Util/control_util.h
@@ -33,6 +33,7 @@
 #define rad_wheel 0.028F 	// wheel radius (m)
 #define cos60 0.5F		// cosine of 60 degrees (wheel angle is at 60 degrees)
 #define sin60 0.866F	// sine of 60 degrees
+bool MOTORS_50W;			// wattage of motors, true = 50 W, false = 30 W
 
 // Wheels
 #define PWM_CUTOFF 200.0F // arbitrary treshold to avoid motor shutdown


### PR DESCRIPTION
The motor wattage is determined by reading out a pin and set in the code. Several constants, that depend on the motor wattage, are then defined. PID values can also be initialized separately for both motors.