### PR TITLE
Improve PID tuning for rotation and improve yaw calibration

### DIFF
--- a/Core/Src/Control/stateControl.c
+++ b/Core/Src/Control/stateControl.c
@@ -32,7 +32,7 @@ int stateControl_Init(){
 		// 50 W
 		initPID(&stateK[body_x], 0.1, 0.0, 0.0);
 		initPID(&stateK[body_y], 0.4, 0.0, 0.0);
-		initPID(&stateK[body_w], 20.0, 30.0, 0.0);
+		initPID(&stateK[body_w], 20.0, 5.0, 0.0);
 	} else {
 		// 30 W
 		initPID(&stateK[body_x], 0.1, 0.0, 0.0);

--- a/Core/Src/Control/yawCalibration.c
+++ b/Core/Src/Control/yawCalibration.c
@@ -83,7 +83,7 @@ static bool isCalibrationNeeded(float visionYaw, float xsensYaw, float yawOffset
 
 	static bool calibrationNeeded = false;
 	static int checkCounter = 0;
-	if (fabs(constrainAngle(visionYaw - (xsensYaw + yawOffset))) > M_PI/180) { // require 1 degree accuracy
+	if (fabs(constrainAngle(visionYaw - (xsensYaw + yawOffset))) > M_PI/180/4) { // require 0.25 degree accuracy
 		checkCounter++;
 	} else {
 		checkCounter = 0;


### PR DESCRIPTION
This PR changes two things:

1) Change PID tuning of the rotation
The integral factor is reduced from a factor of 30 to 5. This reduces overshoot whilst not or barely compromising speed
2) Reduce the necessary difference to trigger yaw recalibration
The necessary difference was large enough to affect how well robots were able to rotate to their target angle. By reducing this, the robots can rotate more accurately. Even with this smaller cutoff, calibrations do not happen too often.

The graphs below demonstrate how this improves the performance of the robot:

In these tests, the robot is asked to rotate to an angle of 0. Its angle according to vision is plotted each tick. The black dashed line indicate the error margin as set in the AI (within this range, the robot is said to be done with rotating).

This graph shows the robot rotating with the new PID tuning
https://drive.google.com/file/d/1-IqELukl9Li18I97-lui4inJpCgkuP-Q/view?usp=sharing

This graph shows the robot rotating with the old PID tuning
https://drive.google.com/file/d/1eYv8RcryrOMDR6HRoE60fKddQq__Gmo6/view?usp=sharing

This graph shows the robot rotating with the new PID tuning [zoomed in]
https://drive.google.com/file/d/12lL_mXx2pJ1Mc9GtWD-nuT-oAKBVV-n-/view?usp=sharing


This graph shows the robot rotating with the old PID tuning [zoomed in]
https://drive.google.com/file/d/1iaJySuF-N4DqoAF22mvBYF55o7l0SsVu/view?usp=sharing

This graph shows the robot rotating with the new PID tuning and improved yaw calibration
https://drive.google.com/file/d/1cQ9sLOal7OV2SsEHIe-5lUZIf1vWM_Rw/view?usp=sharing