### PR TITLE
Implemented channel selection. no jumper = yellow

### DIFF
--- a/Core/Inc/Wireless/Wireless.h
+++ b/Core/Inc/Wireless/Wireless.h
@@ -18,17 +18,29 @@
 #define MAX_BUF_LENGTH 128
 #define AUTO_TX_TIME 120 // (us)
 
-#define WIRELESS_FEEDBACK_CHANNEL -5	// 2.395 GHz
-#define WIRELESS_COMMAND_CHANNEL -15 // 2.385 GHz
+#define WIRELESS_YELLOW_CHANNELS 0
+#define WIRELESS_BLUE_CHANNELS 1
 
+#define WIRELESS_YELLOW_FEEDBACK_CHANNEL -5 // 2.395 GHz
+#define WIRELESS_YELLOW_COMMAND_CHANNEL -15 // 2.385 GHz
+#define WIRELESS_BLUE_FEEDBACK_CHANNEL -25
+#define WIRELESS_BLUE_COMMAND_CHANNEL -35
+
+typedef enum WIRELESS_CHANNEL {
+    YELLOW_CHANNEL = 0,
+    BLUE_CHANNEL = 1
+} WIRELESS_CHANNEL;
 ///////////////////////////////////////////////////// PUBLIC FUNCTION DECLARATIONS
 
-SX1280 * Wireless_Init(float channel, SPI_HandleTypeDef * WirelessSpi);
+SX1280 * Wireless_Init(WIRELESS_CHANNEL channel, SPI_HandleTypeDef * WirelessSpi);
 void Wireless_DeInit();
 void SendPacket(SX1280* SX, uint8_t * data, uint8_t Nbytes);
 void ReceivePacket(SX1280* SX);
 void Wireless_IRQ_Handler(SX1280* SX, uint8_t * data, uint8_t Nbytes);
 void Wireless_DMA_Handler(SX1280* SX, uint8_t output[]);
 bool checkWirelessConnection();
+
+void SX1280_updateChannel(WIRELESS_CHANNEL channel);
+WIRELESS_CHANNEL SX1280_getCurrentChannel();
 
 #endif /* WIRELESS_WIRELESS_H_ */

--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -223,7 +223,15 @@ void init(void){
 	/* Initialize the SX1280 wireless chip */
 	// TODO figure out why a hardfault occurs when this is disabled
 	Putty_printf("Initializing wireless\n");
-    SX = Wireless_Init(WIRELESS_COMMAND_CHANNEL, COMM_SPI);
+
+	if(read_Pin(IN2_pin)){
+		SX = Wireless_Init(BLUE_CHANNEL, COMM_SPI);
+		Putty_printf("Listening on BLUE CHANNEL\n");
+	}else{
+		SX = Wireless_Init(YELLOW_CHANNEL, COMM_SPI);
+		Putty_printf("Listening on YELLOW CHANNEL\n");
+	}
+    
 	SX->SX_settings->syncWords[0] = robot_syncWord[ID];
     setSyncWords(SX, SX->SX_settings->syncWords[0], 0x00, 0x00);
     setRX(SX, SX->SX_settings->periodBase, WIRELESS_RX_COUNT);


### PR DESCRIPTION
Left jumper now controls if the robot plays for the blue or yellow team. No jumper = yellow. Yes jumper = Blue. Tested with two basestations, one for each team, and toggling the jumper successfully moves the robot to the other team. 