### PR TITLE
Quick fix to stop the dribbler from rotating when commands stop

### DIFF
--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -298,6 +298,9 @@ void loop(void){
 		// toggle_Pin(LED5_pin);
         stateControl_ResetAngleI();
         resetRobotCommand(&activeRobotCommand);
+		// Quick fix to also stop the dribbler from rotating when the command is reset
+		// TODO maybe move executeCommand to TIMER_7?
+		dribbler_SetSpeed(0);
 		REM_last_packet_had_correct_version = true;
     }
 


### PR DESCRIPTION
This ensures the dribbler will stop when the commands stop coming in.