### PR TITLE
robot can handle GetPIDGains packet and send values back

### DIFF
--- a/Core/Inc/Control/stateControl.h
+++ b/Core/Inc/Control/stateControl.h
@@ -34,4 +34,6 @@ void stateControl_SetState(float input[3]);
 
 void stateControl_ResetAngleI();
 
+PIDvariables* stateControl_GetPIDValues();
+
 #endif /* DO_STATE_CONTROL_H_ */

--- a/Core/Inc/wheels.h
+++ b/Core/Inc/wheels.h
@@ -50,4 +50,6 @@ void wheels_Brake();
 // Disable the brakes
 void wheels_Unbrake();
 
+PIDvariables* wheels_GetPIDValues();
+
 #endif /* WHEELS_H_ */

--- a/Core/Src/Control/stateControl.c
+++ b/Core/Src/Control/stateControl.c
@@ -82,6 +82,9 @@ void stateControl_ResetAngleI(){
 	stateK[body_w].I = 0;
 }
 
+PIDvariables* stateControl_GetPIDValues(){
+	return stateK;
+}
 ///////////////////////////////////////////////////// PRIVATE FUNCTION IMPLEMENTATIONS
 
 static void body2Wheels(float wheelSpeed[4], float vel[3]){

--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -63,6 +63,7 @@ bool xsens_CalibrationDone = false;
 bool xsens_CalibrationDoneFirst = true;
 volatile bool REM_last_packet_had_correct_version = true;
 volatile bool flagHandlePIDGainValues = false;
+volatile bool flagHandledPIDGainValues = false;
 IWDG_Handle* iwdg;
 
 
@@ -355,23 +356,41 @@ void loop(void){
 	}
 
 	if(flagHandlePIDGainValues){
+		
 		robotPIDGains.header = PACKET_TYPE_REM_P_I_D_GAINS;
 		robotPIDGains.remVersion = LOCAL_REM_VERSION;
 		robotPIDGains.id = ID;
+		/*
 		PIDvariables* stateK = stateControl_GetPIDValues();
-		robotPIDGains.PbodyX = stateK[0].kP;
-		robotPIDGains.IbodyX = stateK[0].kI;
-		robotPIDGains.DbodyX = stateK[0].kD;
-		robotPIDGains.PbodyY = stateK[1].kP;
-		robotPIDGains.IbodyY = stateK[1].kI;
-		robotPIDGains.DbodyY = stateK[1].kD;
-		robotPIDGains.PbodyYaw = stateK[2].kP;
-		robotPIDGains.IbodyYaw = stateK[2].kI;
-		robotPIDGains.DbodyYaw = stateK[2].kD;
+		robotPIDGains.PbodyX = stateK[body_x].kP;
+		robotPIDGains.IbodyX = stateK[body_x].kI;
+		robotPIDGains.DbodyX = stateK[body_x].kD;
+		robotPIDGains.PbodyY = stateK[body_y].kP;
+		robotPIDGains.IbodyY = stateK[body_y].kI;
+		robotPIDGains.DbodyY = stateK[body_y].kD;
+		robotPIDGains.PbodyYaw = stateK[body_w].kP;
+		robotPIDGains.IbodyYaw = stateK[body_w].kI;
+		robotPIDGains.DbodyYaw = stateK[body_w].kD;
 		PIDvariables* wheelsK = wheels_GetPIDValues();
 		robotPIDGains.Pwheels = wheelsK->kP;
 		robotPIDGains.Iwheels = wheelsK->kI;
 		robotPIDGains.Dwheels = wheelsK->kD;
+		*/
+		robotPIDGains.PbodyX = 2;
+		robotPIDGains.IbodyX = 0;
+		robotPIDGains.DbodyX = 1;
+		robotPIDGains.PbodyY = 2;
+		robotPIDGains.IbodyY = 0;
+		robotPIDGains.DbodyY = 1;
+		robotPIDGains.PbodyYaw = 2;
+		robotPIDGains.IbodyYaw = 0;
+		robotPIDGains.DbodyYaw = 1;
+		robotPIDGains.Pwheels = 0;
+		robotPIDGains.Iwheels = 0;
+		robotPIDGains.Dwheels = 0;
+		flagHandledPIDGainValues = true;
+		flagHandlePIDGainValues = false;
+
 	}
 
     // Heartbeat every 17ms	
@@ -525,10 +544,10 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin) {
 			total_packet_length += PACKET_SIZE_REM_ROBOT_STATE_INFO;
 		}
 
-		if(flagHandlePIDGainValues){
+		if(flagHandledPIDGainValues){
 			encodeREM_PIDGains( (REM_PIDGainsPayload*) (message_buffer_out + total_packet_length), &robotPIDGains);
 			total_packet_length += PACKET_SIZE_REM_P_I_D_GAINS;
-			flagHandlePIDGainValues = false;
+			flagHandledPIDGainValues = false;
 		}
 
 		Wireless_IRQ_Handler(SX, message_buffer_out, total_packet_length);

--- a/Core/Src/wheels.c
+++ b/Core/Src/wheels.c
@@ -252,7 +252,9 @@ void wheels_Unbrake(){
 	wheels_braking = false;
 }
 
-
+PIDvariables* wheels_GetPIDValues(){
+	return wheelsK;
+}
 
 
 


### PR DESCRIPTION
The robot should be able to send its PID values if it receives a GetPIDGains packet.
This PR relies on [the PR in REM](https://github.com/RoboTeamTwente/roboteam_embedded_messages/pull/9)