### PR TITLE
Add units to control documentation strings

### DIFF
--- a/Core/Inc/Control/stateControl.h
+++ b/Core/Inc/Control/stateControl.h
@@ -59,21 +59,21 @@ void stateControl_Update();
 
 /**
  * Set the new reference values that the robot should achieve.
- * @param _stateGlobalRef The x, y, w and yaw speeds as instructed by the RobotCommand.
+ * @param _stateGlobalRef The x [m/s], y [m/s] and w [rad/s] speeds and and yaw [rad] as instructed by the RobotCommand.
  */
 void stateControl_SetRef(float _stateGlobalRef[4]);
 
 /**
  * Get the referenced wheel speeds.
  * 
- * @return float* An array with the wheel speeds.
+ * @return float* An array with the wheel speeds [rad/s].
  */
 float* stateControl_GetWheelRef();
 
 /**
  * Set the current state as the estimated state as calculated by stateEstimation
  * 
- * @param _stateLocal The u, v, w and yaw speeds from stateEstimation
+ * @param _stateLocal The u [m/s], v [m/s] and w [rad/s] speeds and yaw [rad] from stateEstimation
  */
 void stateControl_SetState(float _stateLocal[4]);
 

--- a/Core/Inc/Control/stateControl.h
+++ b/Core/Inc/Control/stateControl.h
@@ -59,7 +59,7 @@ void stateControl_Update();
 
 /**
  * Set the new reference values that the robot should achieve.
- * @param _stateGlobalRef The x [m/s], y [m/s] and w [rad/s] speeds and and yaw [rad] as instructed by the RobotCommand.
+ * @param _stateGlobalRef The x [m/s], y [m/s] and w [rad/s] speeds and yaw [rad] as instructed by the RobotCommand.
  */
 void stateControl_SetRef(float _stateGlobalRef[4]);
 

--- a/Core/Inc/Control/stateEstimation.h
+++ b/Core/Inc/Control/stateEstimation.h
@@ -22,15 +22,15 @@
 ///////////////////////////////////////////////////// STRUCTS
 
 typedef struct StateInfo {
-	float visionYaw;					// The yaw for this robot as indicated by vision
+	float visionYaw;					// The yaw for this robot as indicated by vision [rad]
 	bool visionAvailable;				// Wether vision data can be used at this point
-	float xsensAcc[2];					// The acceleration as measured by the IMU in the X and Y directions
-	float xsensYaw;						// They yaw for this robot as indicated by the IMU
-	float rateOfTurn;					// [rad/s]
-	float wheelSpeeds[4];				// The speed for each wheel 
-	float dribblerSpeed;				// The measured speed of the dribbler
-	float dribblerFilteredSpeed;		// The filtered speed of the dribbler
-	float dribbleSpeedBeforeGotBall;	// The speed of the dribbler before it had a ball
+	float xsensAcc[2];					// The acceleration as measured by the IMU in the X and Y directions [m/(s^2)]
+	float xsensYaw;						// They yaw for this robot as indicated by the IMU [rad]
+	float rateOfTurn;					// The angular velocity of the robot [rad/s]
+	float wheelSpeeds[4];				// The speed for each wheel [rad/s]
+	float dribblerSpeed;				// The measured speed of the dribbler [rad/s]
+	float dribblerFilteredSpeed;		// The filtered speed of the dribbler [rad/s]
+	float dribbleSpeedBeforeGotBall;	// The speed of the dribbler before it had a ball [rad/s]
 } StateInfo;
 
 ///////////////////////////////////////////////////// PUBLIC FUNCTION DECLARATIONS
@@ -55,12 +55,12 @@ void stateEstimation_Update(StateInfo* input);
 /**
  * Get the current estimated local state
  * 
- * @param _stateLocal The curent state for u, v, w and yaw
+ * @param _stateLocal The curent state for u [m/s], v [m/s], w [rad/s] and yaw [rad]
  */
 void stateEstimation_GetState(float _stateLocal[4]);
 
 /**
- * Identical to stateEstimation_GetState(), but only returns w.
+ * Identical to stateEstimation_GetState(), but only returns w [rad/s].
  * 
  * @return float Rate of return
  */

--- a/Core/Inc/Control/yawCalibration.h
+++ b/Core/Inc/Control/yawCalibration.h
@@ -23,17 +23,17 @@
 /**
  * Calibrates the yaw measured by the IMU.
  * 
- * @param xsensYaw          The yaw as currently being measured by the IMU.
- * @param visionYaw         The yaw as currently being observed by vision
+ * @param xsensYaw          The yaw as currently being measured by the IMU [rad]
+ * @param visionYaw         The yaw as currently being observed by vision [rad]
  * @param visionAvailable   Wether vision can be used at this moment
- * @param rateOfTurn        Our current rate of turn (if it is too high, we cannot reliably calibrate the yaw)
+ * @param rateOfTurn        Our current rate of turn (if it is too high, we cannot reliably calibrate the yaw) [rad/s]
  */
 void yaw_Calibrate(float xsensYaw, float visionYaw, bool visionAvailable, float rateOfTurn);
 
 /**
  * Get the calibrated yaw
  * 
- * @return float 
+ * @return float [rad]
  */
 float yaw_GetCalibratedYaw();
 

--- a/Core/Src/Control/stateControl.c
+++ b/Core/Src/Control/stateControl.c
@@ -204,7 +204,7 @@ static void body2Wheels(float wheelSpeed[4], float stateLocal[3]){
 		wheelSpeed[wheel] = wheelSpeed[wheel] / rad_wheel;
 	}
 
-	// If we use angular velocities, take those into account too.
+	// If we do not use angular velocities (w), remove these.
 	if (!useAbsoluteAngle) {
         for (wheel_names wheel=wheels_RF; wheel<=wheels_RB; wheel++){
             wheelSpeed[wheel] += stateLocal[vel_w] * rad_robot / rad_wheel;

--- a/Core/Src/Control/stateEstimation.c
+++ b/Core/Src/Control/stateEstimation.c
@@ -8,11 +8,11 @@
 /**
  * @brief The local current state of the robot.
  * 
- * The state consists out of u, v, w and yaw.
+ * The state consists out of u [m/s], v [m/s], w [rad/s] and yaw [rad].
  */
 static float stateLocal[4] = {0.0f};
 
-// The pseudoinverse of the velocity coupling matrix, used to transform wheel speeds into local u, v and w speeds.
+// The pseudoinverse of the velocity coupling matrix, used to transform wheel speeds into local u [m/s], v [m/s] and w [rad/s] speeds.
 static float Dinv[12] = {0.0f};
 
 ///////////////////////////////////////////////////// PRIVATE FUNCTION DECLARATIONS
@@ -21,7 +21,7 @@ static float Dinv[12] = {0.0f};
  * Translates the velocities from the wheels to the body velocities.
  * 
  * @param wheelSpeeds The speed achieved by each wheel [rad/s].
- * @param output 	  The u, v and w speeds from a body perspective [m/s].
+ * @param output 	  The u [m/s], v [m/s] and w [rad/s] speeds from a body perspective.
  */
 static void wheels2Body(float wheelSpeeds[4], float output[3]);
 
@@ -29,8 +29,8 @@ static void wheels2Body(float wheelSpeeds[4], float output[3]);
  * Smoothens out the IMU rate of turn data.
  * While this does decrease the response time slightly, it allows for smoother rotations.
  * 
- * @param rateOfTurn The current rate of turn as measured by the IMU.
- * @return float     The smoothed out rate of turn.
+ * @param rateOfTurn The current rate of turn as measured by the IMU [rad/s].
+ * @return float     The smoothed out rate of turn [rad/s].
  */
 float smoothen_rateOfTurn(float rateOfTurn);
 
@@ -117,7 +117,7 @@ static void wheels2Body(float wheelSpeeds[4], float output[3]){
 	output[vel_v] = wheelSpeeds[0] * Dinv[4] + wheelSpeeds[1] * Dinv[5] + wheelSpeeds[2] * Dinv[6] + wheelSpeeds[3] * Dinv[7];
 	output[vel_w] = wheelSpeeds[0] * Dinv[8] + wheelSpeeds[1] * Dinv[9] + wheelSpeeds[2] * Dinv[10] + wheelSpeeds[3] * Dinv[11];
 
-	// Translate the rotational velocity to m/s.
+	// Translate the rotational velocity of the robot back to rad/s.
 	output[vel_w] = output[vel_w] / rad_robot;
 }
 


### PR DESCRIPTION
I've added the units between [] for more clarity in most of the control code, since this used to be quite confusing from time to time