### PR TITLE
Moved up wheels_Init() to prevent wheels spinning at boot

### DIFF
--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -273,6 +273,9 @@ void init(void){
 	// Turn off all leds. Use leds to indicate init() progress
 	set_Pin(LED0_pin, 0); set_Pin(LED1_pin, 0); set_Pin(LED2_pin, 0); set_Pin(LED3_pin, 0); set_Pin(LED4_pin, 0); set_Pin(LED5_pin, 0); set_Pin(LED6_pin, 0);
 	
+	// Initialize (and break) the wheels as soon as possible. This prevents wheels from randomly spinning when powering up the robot.
+	wheels_Init();
+
 { // ====== WATCHDOG TIMER, COMMUNICATION BUFFERS ON TOPBOARD, BATTERY, ROBOT SWITCHES, OUTGOING PACKET HEADERS
 	/* Enable the watchdog timer and set the threshold at 5 seconds. It should not be needed in the initialization but
 	 sometimes for some reason the code keeps hanging when powering up the robot using the power switch. It's not nice
@@ -336,10 +339,9 @@ void init(void){
 	
 	set_Pin(LED1_pin, 1);
 
-{ // ====== INITIALIZE CONTROL CONSTANTS, WHEELS, STATE CONTROL, STATE ESTIMATION, SHOOTER, DRIBBLER, BALLSENSOR
+{ // ====== INITIALIZE CONTROL CONSTANTS, STATE CONTROL, STATE ESTIMATION, SHOOTER, DRIBBLER, BALLSENSOR
     // Initialize control constants
     control_util_Init();
-    wheels_Init();
     stateControl_Init();
     stateEstimation_Init();
     shoot_Init();


### PR DESCRIPTION
For whatever reason, enabling the SDcard causes the wheels to spin at boot, until wheels_Init() is called. Regardless, having the wheels break as soon as possible is always a good idea. Therefore, moved up wheels_Init() to the beginning of the init() function.