### PR TITLE
Purge the PID controllers from the individual wheels

### DIFF
--- a/Core/Inc/Control/stateControl.h
+++ b/Core/Inc/Control/stateControl.h
@@ -36,10 +36,6 @@
 #define default_I_gain_yaw 5.0
 #define default_D_gain_yaw 0.0
 
-#define default_P_gain_wheels 2.0
-#define default_I_gain_wheels 0.0
-#define default_D_gain_wheels 0.0
-
 ///////////////////////////////////////////////////// PUBLIC FUNCTION DECLARATIONS
 
 /**

--- a/Core/Inc/peripherals/wheels.h
+++ b/Core/Inc/peripherals/wheels.h
@@ -26,7 +26,6 @@
 #include "control_util.h"
 #include "gpio_util.h"
 #include "tim_util.h"
-#include "REM_RobotSetPIDGains.h"
 
 ///////////////////////////////////////////////////// PUBLIC FUNCTION DECLARATIONS
 
@@ -44,8 +43,6 @@ void wheels_SetSpeeds(const float speeds[4]);
 void wheels_GetMeasuredSpeeds(float speeds[4]);
 // Get the current wheel PWMs
 void wheels_GetPWM(uint32_t pwms[4]);
-// Set the PID gains for the wheels
-void wheels_SetPIDGains(REM_RobotSetPIDGains* PIDGains);
 // Get the current status of the brakes
 bool wheels_GetWheelsBraking();
 // Enable the brakes

--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -682,7 +682,6 @@ void handleRobotSetPIDGains(uint8_t* packet_buffer){
 	REM_last_packet_had_correct_version &= REM_RobotSetPIDGains_get_remVersion(rspidgp) == REM_LOCAL_VERSION;
 	decodeREM_RobotSetPIDGains(&robotSetPIDGains, rspidgp);
 	stateControl_SetPIDGains(&robotSetPIDGains);
-	wheels_SetPIDGains(&robotSetPIDGains);
 }
 
 void handleRobotMusicCommand(uint8_t* packet_buffer){


### PR DESCRIPTION
It would make more sense to only have PID controllers on the body velocities of the robot (u, v & w). The first step in this process is to get rid of the controllers on each wheel. 