### PR TITLE
Only control the robot with PID

### DIFF
--- a/Core/Src/Control/stateControl.c
+++ b/Core/Src/Control/stateControl.c
@@ -234,9 +234,9 @@ static void velocityControl(float stateLocal[3], float stateGlobalRef[4], float 
 	float velvErr = (stateLocalRef[vel_v] - stateLocal[vel_v]);
 	float velwErr = (stateLocalRef[vel_w] - stateLocal[vel_w]);
 
-	stateLocalRef[vel_u] += PID(veluErr, &stateLocalK[vel_u]);
-	stateLocalRef[vel_v] += PID(velvErr, &stateLocalK[vel_v]);
-	stateLocalRef[vel_w] += PID(velwErr, &stateLocalK[vel_w]);
+	stateLocalRef[vel_u] = PID(veluErr, &stateLocalK[vel_u]);
+	stateLocalRef[vel_v] = PID(velvErr, &stateLocalK[vel_v]);
+	stateLocalRef[vel_w] = PID(velwErr, &stateLocalK[vel_w]);
 
 	body2Wheels(velocityWheelRef, stateLocalRef); //translate velocity to wheel speed
 }


### PR DESCRIPTION
At this moment the robot is being controlled by adding the value from the PID controller to the instruction that was originally sent to the robot. However, the robot should act solely on the result that has been generated by the PID controller. 