### PR TITLE
Allow for disabling UART PC connection with FT2 switch

### DIFF
--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -46,6 +46,10 @@
 
 uint8_t ROBOT_ID;
 WIRELESS_CHANNEL ROBOT_CHANNEL;
+
+/* Whether the robot should accept an uart connection from the PC */
+volatile bool ENABLE_UART_PC = true;
+
 volatile bool IS_RUNNING_TEST = false;
 volatile bool ROBOT_INITIALIZED = false;
 
@@ -305,6 +309,7 @@ void init(void){
 	ROBOT_ID = get_Id();
 	ROBOT_CHANNEL = read_Pin(FT1_pin) == GPIO_PIN_SET ? BLUE_CHANNEL : YELLOW_CHANNEL;
 	IS_RUNNING_TEST = read_Pin(FT0_pin);
+	ENABLE_UART_PC = read_Pin(FT2_pin);
 	
 	
 	initPacketHeader((REM_Packet*) &activeRobotCommand, ROBOT_ID, ROBOT_CHANNEL, REM_PACKET_TYPE_REM_ROBOT_COMMAND);
@@ -344,8 +349,13 @@ void init(void){
 	}
 	#endif
 
-	/* === Wired communication with robot; Can now receive RobotCommands (and other REM packets) via UART */
-	REM_UARTinit(UART_PC);
+	// Sometimes the UART pin for the programmer is floating, causing the robot to not boot. 
+	// As a temporary fix one can disable the uart initialization with the FT_2 switch on the robot.
+	// TODO: This will need a proper fix later on.
+	if (ENABLE_UART_PC) {
+		/* === Wired communication with robot; Can now receive RobotCommands (and other REM packets) via UART */
+		REM_UARTinit(UART_PC);
+	}
 	}
 	
 	set_Pin(LED1_pin, 1);


### PR DESCRIPTION
Sometimes the UART pins on the topboard tend to float, not allowing the robot to continue booting any further.
For some time now it has been to solution to connect a jumper cable to the UART port and to ground, as an alternative solution one can now explicitly disable the UART connection with the PC by disabling the FT2 pin on the robot. 

@emielsteerneman I am however not completely sure if only not initializing the PC connection is enough to fully disable it. It does no longer allow me to send any commands to robot, which is a good thing I guess. But perhaps something more needs to be done.