### PR TITLE
Disable ballsensor logging, since it clutters the robot output

### DIFF
--- a/Core/Src/peripherals/ballsensor.c
+++ b/Core/Src/peripherals/ballsensor.c
@@ -168,8 +168,8 @@ void ballSensor_IRQ_Handler() {
 			// Received interrupt that can't be handled
 			uint8_t message_size = data[1];
 			for(uint16_t at = 0; at < message_size; at += 10){
-				LOG_printf("[%d] %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X\n",
-				at, data[at+0], data[at+1], data[at+2], data[at+3], data[at+4], data[at+5], data[at+6], data[at+7], data[at+8], data[at+9]);
+				// LOG_printf("[%d] %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X\n",
+				// at, data[at+0], data[at+1], data[at+2], data[at+3], data[at+4], data[at+5], data[at+6], data[at+7], data[at+8], data[at+9]);
 			}
 		}
 	}

--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -357,7 +357,9 @@ void init(void){
     stateEstimation_Init();
     shoot_Init();
     dribbler_Init();
-    if(ballSensor_Init()) LOG("[init:"STRINGIZE(__LINE__)"] Ballsensor initialized\n");
+	// TODO: Currently the ball sensor initialization is just disabled. 
+	// Since we will no longer use it anymore this should be fully removed from the code.
+    // if(ballSensor_Init()) LOG("[init:"STRINGIZE(__LINE__)"] Ballsensor initialized\n");
 	LOG_sendAll();
 	}
 


### PR DESCRIPTION
The ball sensor code was logging its values directly with the LOG command, cluttering the output in test scripts. For the sake of readability of other values I have turned it off, since we no longer utilize the ball sensor anyhow. 