### PR TITLE
Update constant slippage corrections values for RoboCup 2023

### DIFF
--- a/Core/Src/Control/stateControl.c
+++ b/Core/Src/Control/stateControl.c
@@ -224,11 +224,6 @@ static void velocityControl(float stateLocal[3], float stateGlobalRef[4], float 
 	float stateLocalRef[3] = {0, 0, 0};
 	global2Local(stateGlobalRef, stateLocalRef, stateLocal[yaw]); //transfer global to local
 
-	// Manually adjusting velocity command
-	//     Explanation: see Velocity Difference file on drive (https://docs.google.com/document/d/1pGKysiwpu19DKLpAZ4GpluMV7UBhBQZ65YMTtI7bd_8/)
-	stateLocalRef[vel_u] = 1.12 * stateLocalRef[vel_u];
-	stateLocalRef[vel_v] = 1.1 * stateLocalRef[vel_v];
-
 	// Local control
 	float veluErr = (stateLocalRef[vel_u] - stateLocal[vel_u]);
 	float velvErr = (stateLocalRef[vel_v] - stateLocal[vel_v]);

--- a/Core/Src/Control/stateEstimation.c
+++ b/Core/Src/Control/stateEstimation.c
@@ -89,6 +89,11 @@ void stateEstimation_Update(StateInfo* input) {
 	stateLocal[vel_v] = kalman_State[2];
 	stateLocal[vel_w] = smoothen_rateOfTurn(input->rateOfTurn);
 	stateLocal[yaw] = calibratedYaw;
+
+	// Compensate for constant slippage by multiplying with empirically determined values.
+	//  Explanation: https://wiki.roboteamtwente.nl/technical/control/slippage
+	stateLocal[vel_u] = 0.92 * stateLocal[vel_u];
+	stateLocal[vel_v] = 0.9 * stateLocal[vel_v];
 }
 
 void stateEstimation_GetState(float _stateLocal[4]) {


### PR DESCRIPTION
This PR moves the correction for constant slippage to state estimation where it belongs (estimation error, not control error). 

Also the values have been updated by driving forwards, sideways on the RoboCup 2023 fields and comparing both the vision and encoder values.