### PR TITLE
Restart IMU initialization for a maximum of 5 times

### DIFF
--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -48,7 +48,7 @@ uint8_t ROBOT_ID;
 WIRELESS_CHANNEL ROBOT_CHANNEL;
 
 /* How often should the IMU try to calibrate before the robot gives up? */
-uint16_t MTi_max_init_attempts = 5;
+uint16_t MTi_MAX_INIT_ATTEMPTS = 5;
 
 /* Whether the robot should accept an uart connection from the PC */
 volatile bool ENABLE_UART_PC = true;
@@ -419,12 +419,12 @@ void init(void){
 
 	// Check whether the MTi is already intialized.
 	// If the 3rd and 4th bit of the statusword are non-zero, then the initializion hasn't completed yet.
-	while ((MTi == NULL || (MTi->statusword & (0x18)) != 0) && MTi_made_init_attempts < MTi_max_init_attempts) {
+	while ((MTi == NULL || (MTi->statusword & (0x18)) != 0) && MTi_made_init_attempts < MTi_MAX_INIT_ATTEMPTS) {
 		MTi = MTi_Init(1, XFP_VRU_general);
 		IWDG_Refresh(iwdg);
 
 		if (MTi_made_init_attempts > 0) {
-			LOG_printf("[init:"STRINGIZE(__LINE__)"] Failed to initialize MTi in attempt %d out of %d\n", MTi_made_init_attempts, MTi_max_init_attempts);
+			LOG_printf("[init:"STRINGIZE(__LINE__)"] Failed to initialize MTi in attempt %d out of %d\n", MTi_made_init_attempts, MTi_MAX_INIT_ATTEMPTS);
 		}
 		MTi_made_init_attempts += 1;
 		LOG_sendAll();
@@ -435,7 +435,7 @@ void init(void){
 
 	// If after the maximum number of attempts the calibration still failed, play a warning sound... :(
 	if (MTi == NULL || (MTi->statusword & (0x18)) != 0) {
-		LOG_printf("[init:"STRINGIZE(__LINE__)"] Failed to initialize MTi after %d out of %d attempts\n", MTi_made_init_attempts, MTi_max_init_attempts);
+		LOG_printf("[init:"STRINGIZE(__LINE__)"] Failed to initialize MTi after %d out of %d attempts\n", MTi_made_init_attempts, MTi_MAX_INIT_ATTEMPTS);
 		buzzer_Play_WarningOne();
 		HAL_Delay(1500); // The duration of the sound
 	}

--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -427,6 +427,7 @@ void init(void){
 		HAL_Delay(1500); // The duration of the sound
 	}
 	LOG_sendAll();
+}
 	
 	set_Pin(LED4_pin, 1);
 
@@ -473,6 +474,7 @@ void init(void){
 
 	ROBOT_INITIALIZED = true;
 }
+
 
 
 


### PR DESCRIPTION
Quite often people move the robot on accident when they turn it on. This causes the initialization of the IMU to fail. In order to somewhat mitigate this, the initialization is attempted for 5 times.

If the robot cannot initialize the IMU within these 5 attempts, the robot will remain in halt mode, just as the current implementation.