### PR TITLE
Allow to kill a robot remotely

### DIFF
--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -659,6 +659,10 @@ void handleRobotMusicCommand(uint8_t* packet_buffer){
 	robot_setRobotMusicCommandPayload(rmcp);
 }
 
+void handleRobotKillCommand(){
+	set_Pin(BAT_KILL_pin, 0);
+}
+
 void robot_setRobotCommandPayload(REM_RobotCommandPayload* rcp){
 	decodeREM_RobotCommand(&activeRobotCommand, rcp);
 	timestamp_last_packet_serial = HAL_GetTick();
@@ -707,6 +711,11 @@ bool handlePacket(uint8_t* packet_buffer, uint8_t packet_length){
 
 			case REM_PACKET_TYPE_REM_SX1280FILLER:
 				total_bytes_processed += REM_PACKET_SIZE_REM_SX1280FILLER;
+				break;
+
+			case REM_PACKET_TYPE_REM_ROBOT_KILL_COMMAND:
+				handleRobotKillCommand();
+				total_bytes_processed += REM_PACKET_TYPE_REM_ROBOT_KILL_COMMAND;
 				break;
 
 

--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -37,6 +37,7 @@
 #include "REM_SX1280Filler.h"
 #include "REM_RobotMusicCommand.h"
 #include "REM_Log.h"
+#include "REM_RobotKillCommand.h"
 
 #include <time.h>
 #include <unistd.h>


### PR DESCRIPTION
Robots are not supposed to move when they do not receive any commands anymore. However, sometimes this is not always the case... 

Hence it is a good idea to remotely turn of a robot in case of an emergency. 

This PR is related to the PR here RoboTeamTwente/roboteam_embedded_messages#17
The related PR that updates the basestation can be found here: RoboTeamTwente/Basestation#36