### PR TITLE
Merge Fix/low velocity error to development

### DIFF
--- a/Core/Src/Control/stateEstimation.c
+++ b/Core/Src/Control/stateEstimation.c
@@ -112,16 +112,17 @@ float stateEstimation_GetFilteredRoT() {
 ///////////////////////////////////////////////////// PRIVATE FUNCTION IMPLEMENTATIONS
 
 static void wheels2Body(float wheelSpeeds[4], float output[3]){
-
+	float wheelSpeedsLinear[4]; // The linear speed for each wheel [m/s]
+	
 	// Translate angular wheel velocities [rad/s] into regular velocities [m/s] on the outside of each wheel.
 	for (wheel_names wheel=wheels_RF; wheel <= wheels_RB; wheel++) {
-		wheelSpeeds[wheel] = wheelSpeeds[wheel] * rad_wheel;
+		wheelSpeedsLinear[wheel] = wheelSpeeds[wheel] * rad_wheel;
 	}
 
 	// Translate the wheel speeds into local u, v and r * w speeds.
-	output[vel_u] = wheelSpeeds[0] * Dinv[0] + wheelSpeeds[1] * Dinv[1] + wheelSpeeds[2] * Dinv[2] + wheelSpeeds[3] * Dinv[3];
-	output[vel_v] = wheelSpeeds[0] * Dinv[4] + wheelSpeeds[1] * Dinv[5] + wheelSpeeds[2] * Dinv[6] + wheelSpeeds[3] * Dinv[7];
-	output[vel_w] = wheelSpeeds[0] * Dinv[8] + wheelSpeeds[1] * Dinv[9] + wheelSpeeds[2] * Dinv[10] + wheelSpeeds[3] * Dinv[11];
+	output[vel_u] = wheelSpeedsLinear[0] * Dinv[0] + wheelSpeedsLinear[1] * Dinv[1] + wheelSpeedsLinear[2] * Dinv[2] + wheelSpeedsLinear[3] * Dinv[3];
+	output[vel_v] = wheelSpeedsLinear[0] * Dinv[4] + wheelSpeedsLinear[1] * Dinv[5] + wheelSpeedsLinear[2] * Dinv[6] + wheelSpeedsLinear[3] * Dinv[7];
+	output[vel_w] = wheelSpeedsLinear[0] * Dinv[8] + wheelSpeedsLinear[1] * Dinv[9] + wheelSpeedsLinear[2] * Dinv[10] + wheelSpeedsLinear[3] * Dinv[11];
 
 	// Translate the rotational velocity of the robot back to rad/s.
 	output[vel_w] = output[vel_w] / rad_robot;

--- a/Core/Src/peripherals/wheels.c
+++ b/Core/Src/peripherals/wheels.c
@@ -177,10 +177,10 @@ void wheels_Update(){
     feed_forward[wheel] = 0;
 		} 
 		else if (wheels_commanded_speeds[wheel] > 0) {
-    feed_forward[wheel] += 13;
+	feed_forward[wheel] = wheels_commanded_speeds[wheel] + 13;
     	}
 		else if (wheels_commanded_speeds[wheel] < 0) {
-    feed_forward[wheel] -= 15;
+	feed_forward[wheel] = wheels_commanded_speeds[wheel] - 13;
     	}
 
 		// Add PID to commanded speed and convert to PWM

--- a/Core/Src/peripherals/wheels.c
+++ b/Core/Src/peripherals/wheels.c
@@ -170,8 +170,21 @@ void wheels_Update(){
 			wheelsK[wheel].I = 0;
 		}
 
+		float feed_forward[4];
+		float threshold = 0.05;
+
+		if (abs(wheels_commanded_speeds[wheel]) < threshold) {
+    feed_forward[wheel] = 0;
+		} 
+		else if (wheels_commanded_speeds[wheel] > 0) {
+    feed_forward[wheel] += 13;
+    	}
+		else if (wheels_commanded_speeds[wheel] < 0) {
+    feed_forward[wheel] -= 15;
+    	}
+
 		// Add PID to commanded speed and convert to PWM
-		int32_t wheel_speed = OMEGAtoPWM * (wheels_commanded_speeds[wheel] + PID(angular_velocity_error, &wheelsK[wheel])); 
+		int32_t wheel_speed = OMEGAtoPWM * (feed_forward[wheel] + PID(angular_velocity_error, &wheelsK[wheel])); 
 
 		// Determine direction and if pwm is negative, switch directions
 		// PWM < 0 : CounterClockWise. Direction = 0


### PR DESCRIPTION
I just copy pasted the branches from Jan Geert and Leonie, they are called wheel_velocity_estimate and wheel_feedforward_friction. The point is to make a new clean branch (with clean commits) and merge it with development.

This branch fixes the low velocity error, by mainly correcting our friction. We implemented the dry friction in the feed forward term (in the past, that was done in a weird way by adding a magic factor). Our friction is now different depending on the velocity of the robot (it is different whether it drives forward or backward). 

Later on, we want to delete the branches wheel_velocity_estimate and wheel_feedforward_friction and only keep this current low_velocity_error branch to merge it to the main one.

wheel_velocity_estimate and wheel_feedforward_friction branches come from the branch feature/record_wheel_ref, which is used to record wheel data on the SD card of the robot. Thus, we want to have the low velocity error branch and the record_wheel_ref and 2 distinct branches for more clarity since they deal with two different problems.