### PR TITLE
Fix/timestamp not at correct frequency

### DIFF
--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -941,6 +941,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
 		}
 
 		flag_sdcard_write_feedback = true;
+		unix_timestamp += 1;
 
 	}
 	else if (htim->Instance == TIM_BUZZER->Instance) {
@@ -953,5 +954,4 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
 		shoot_Callback();
 	}
 
-	unix_timestamp += 1	;
 }

--- a/Core/Src/robot.c
+++ b/Core/Src/robot.c
@@ -869,7 +869,8 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
             return;
         }
 
-		if( halt && !test_isTestRunning(square)){
+		if(halt && !test_isTestRunning(square)) {
+			unix_initalized = false;
 			wheels_Stop();
 			return;
 		}


### PR DESCRIPTION
Moved the line where unix_timestamp gest increased to be only increased when htim->Instance == TIM_CONTROL->Instance and not when any timer calls HAL_TIM_PeriodElapsedCallback